### PR TITLE
Added an additional command to insert a direct zotero link

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { App, FileSystemAdapter, MarkdownSourceView, MarkdownView, normalizePath
 // @ts-ignore
 import { watch } from 'original-fs';
 import * as path from 'path';
-import { InsertCitationModal, OpenNoteModal } from './modals';
+import { InsertCitationModal, InsertZoteroDirectLinkModal, OpenNoteModal } from './modals';
 import { NoticeExt } from './obsidian-extensions';
 
 import { CitationsPluginSettings, CitationSettingTab, IIndexable } from './settings';
@@ -94,7 +94,19 @@ export default class CitationPlugin extends Plugin {
 				modal.open();
 			}
 		})
-
+		
+		this.addCommand({
+			id: "insert-zotero-link",
+			name: "Insert Zotero direct-link",
+			hotkeys: [
+				{modifiers: ["Ctrl", "Shift"], key: "z"},
+			],
+			callback: () => {
+				let modal = new InsertZoteroDirectLinkModal(this.app, this);
+				modal.open();
+			}
+		})
+		
 		this.addSettingTab(new CitationSettingTab(this.app, this));
 	}
 
@@ -203,5 +215,10 @@ export default class CitationPlugin extends Plugin {
 			// console.log(this.app.metadataCache.fileToLinktext(file, this.app.vault.getRoot().path, true))
 			this.editor.replaceRange(linkText, this.editor.getCursor());
 		})
+	}
+
+	async  insertZoteroDirectLink(citekey: string, zoteroLink: string) {
+		let zoteroLinkText = '[@' + citekey + '](' + zoteroLink + ')';
+		this.editor.replaceRange(zoteroLinkText, this.editor.getCursor());
 	}
 }

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -99,3 +99,19 @@ export class InsertCitationModal extends SearchModal {
 		this.plugin.insertLiteratureNoteLink(item.id);
 	}
 }
+
+export class InsertZoteroDirectLinkModal extends SearchModal {
+	constructor(app: App, plugin: CitationPlugin) {
+	  super(app, plugin);
+  
+	  this.setInstructions([
+			  {command: "↑↓", purpose: "to navigate"},
+			  {command: "↵", purpose: "to insert zotero direct-link"},
+			  {command: "esc", purpose: "to dismiss"},
+		  ])
+	}
+  	
+	  onChooseItem(item: Entry, evt: any): void {
+		this.plugin.insertZoteroDirectLink(item.id, item.zoteroSelectURI);
+	  }
+  }


### PR DESCRIPTION
Hey there! I added a feature that fits my workflow a bit more. 

I personally don't maintain a _single_ reference note per citation, but instead cite the same zotero cite-key in many notes whenever I want to reference an idea from a paper. So, it is far more useful for me to just make a markdown link that points directly to zotero instead of having to create a dedicated note for the citation. 

The way I've done it is to add a separate command that generates a generic markdown link with the zotero:/// URI. The changes are very minimal and basically builds on what you've already written. 

Obviously I understand if you never intended your plugin to be used this way. I'll leave it to you to decide if this feature is worth pulling into your repo! :)