### PR TITLE
Fix success notification for export path setting.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -144,14 +144,15 @@ export default class CitationPlugin extends Plugin {
       const filePath = this.resolveLibraryPath(
         this.settings.citationExportPath,
       );
-      FileSystemAdapter.readLocalFile(filePath)
+      return FileSystemAdapter.readLocalFile(filePath)
         .then((buffer) => {
           // If there is a remaining error message, hide it
           this.loadErrorNotifier.hide();
 
           this.onLibraryUpdate(buffer);
         })
-        .catch(() => this.loadErrorNotifier.show());
+        .catch(() => this.loadErrorNotifier.show())
+        .then();
     } else {
       console.warn(
         'Citations plugin: citation export path is not set. Please update plugin settings.',


### PR DESCRIPTION
Before this change when library wasn't loaded yet success notification
would show a message that 0 references are loaded because of a race
condition. This change fixes it and makes success notification show
correct information for the initial load.