### PR TITLE
Add notes field to Bibtex entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "obsidian-citation-plugin",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@retorquere/bibtex-parser": "^3.2.30",

--- a/src/__tests__/library.bib
+++ b/src/__tests__/library.bib
@@ -15,7 +15,8 @@ pmid = {11459040},
 title = {{An Overview of Biomineralization Processes and the Problem of the Vital Effect}},
 url = {http://rimg.geoscienceworld.org/cgi/doi/10.2113/0540001},
 volume = {54},
-year = {2003}
+year = {2003},
+note = {This is a test note with some \textbf{formatting}.}
 }
 
 @online{abnar2019blackbox,

--- a/src/__tests__/types.spec.ts
+++ b/src/__tests__/types.spec.ts
@@ -24,6 +24,7 @@ const expectedRender: Record<string, string>[] = [
     containerTitle: 'Rev. Mineral. Geochemistry',
     DOI: '10.2113/0540001',
     eprint: '1105.3402',
+    note: 'This is a test note with some <b>formatting</b>.',
     page: '1-29',
     title:
       'An Overview of Biomineralization Processes and the Problem of the Vital Effect',
@@ -96,7 +97,7 @@ const expectedRender: Record<string, string>[] = [
  * Fields available only in the BibLaTeX format, and which shouldn't be checked
  * against CSL format
  */
-const BIBLATEX_FIELDS_ONLY = ['eprint', 'eprinttype', 'files'];
+const BIBLATEX_FIELDS_ONLY = ['eprint', 'eprinttype', 'files', 'note'];
 
 // Test whether loaded and expected libraries are the same, ignoring casing and
 // hyphenation and the `entry` field

--- a/src/main.ts
+++ b/src/main.ts
@@ -399,3 +399,4 @@ export default class CitationPlugin extends Plugin {
     this.editor.replaceRange(citation, this.editor.getCursor());
   }
 }
+//# sourceURL=main.js

--- a/src/main.ts
+++ b/src/main.ts
@@ -399,4 +399,3 @@ export default class CitationPlugin extends Plugin {
     this.editor.replaceRange(citation, this.editor.getCursor());
   }
 }
-//# sourceURL=main.js

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export const TEMPLATE_VARIABLES = {
   eprint: '',
   eprinttype: '',
   eventPlace: 'Location of event',
+  note: '',
   page: 'Page or page range',
   publisher: '',
   publisherPlace: 'Location of publisher',
@@ -29,7 +30,6 @@ export const TEMPLATE_VARIABLES = {
   URL: '',
   year: 'Publication year',
   zoteroSelectURI: 'URI to open the reference in Zotero',
-  note: ''
 };
 
 export class Library {
@@ -55,6 +55,7 @@ export class Library {
       eprint: entry.eprint,
       eprinttype: entry.eprinttype,
       eventPlace: entry.eventPlace,
+      note: entry.note,
       page: entry.page,
       publisher: entry.publisher,
       publisherPlace: entry.publisherPlace,
@@ -62,7 +63,6 @@ export class Library {
       URL: entry.URL,
       year: entry.year?.toString(),
       zoteroSelectURI: entry.zoteroSelectURI,
-      note: entry.note
     };
 
     return { entry: entry.toJSON(), ...shortcuts };
@@ -170,10 +170,11 @@ export abstract class Entry {
 
   protected _note?: string[];
 
-  public get note():string {
-    if (!this._note) return null
-    return this._note.map(el => el.replace(/(zotero:\/\/.+)/g, "[Link]($1)")).join("\n\n");
-  } 
+  public get note(): string {
+    return this._note
+      ?.map((el) => el.replace(/(zotero:\/\/.+)/g, '[Link]($1)'))
+      .join('\n\n');
+  }
 
   /**
    * A URI which will open the relevant entry in the Zotero client.
@@ -319,7 +320,7 @@ const BIBLATEX_PROPERTY_MAPPING: Record<string, string> = {
   venue: 'eventPlace',
   year: '_year',
   publisher: 'publisher',
-  note:'_note'
+  note: '_note',
 };
 
 // BibLaTeX parser returns arrays of property values (allowing for repeated

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export const TEMPLATE_VARIABLES = {
   URL: '',
   year: 'Publication year',
   zoteroSelectURI: 'URI to open the reference in Zotero',
+  note: ''
 };
 
 export class Library {
@@ -61,6 +62,7 @@ export class Library {
       URL: entry.URL,
       year: entry.year?.toString(),
       zoteroSelectURI: entry.zoteroSelectURI,
+      note: entry.note
     };
 
     return { entry: entry.toJSON(), ...shortcuts };
@@ -165,6 +167,13 @@ export abstract class Entry {
       ? parseInt(this._year)
       : this.issuedDate?.getUTCFullYear();
   }
+
+  protected _note?: string[];
+
+  public get note():string {
+    if (!this._note) return null
+    return this._note.map(el => el.replace(/(zotero:\/\/.+)/g, "[Link]($1)")).join("\n\n");
+  } 
 
   /**
    * A URI which will open the relevant entry in the Zotero client.
@@ -309,7 +318,8 @@ const BIBLATEX_PROPERTY_MAPPING: Record<string, string> = {
   url: 'URL',
   venue: 'eventPlace',
   year: '_year',
-  publisher: 'publisher'
+  publisher: 'publisher',
+  note:'_note'
 };
 
 // BibLaTeX parser returns arrays of property values (allowing for repeated
@@ -352,6 +362,7 @@ export class EntryBibLaTeXAdapter extends Entry {
   titleShort?: string;
   URL?: string;
   _year?: string;
+  _note?: string[];
 
   constructor(private data: EntryDataBibLaTeX) {
     super();


### PR DESCRIPTION
Expose the bibtex notes field on the Entry object so that it can be referenced in templates. Useful when using Zotfile to extract highlights, which are stored as notes.