### PR TITLE
add a command for manual update bib data

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -137,6 +137,15 @@ export default class CitationPlugin extends Plugin {
     });
 
     this.addCommand({
+      id: 'update-bib-data',
+      name: 'Update bib data',
+      hotkeys: [{ modifiers: ['Ctrl', 'Shift'], key: 'r' }],
+      callback: () => {
+        this.loadLibrary();
+      },
+    });
+
+    this.addCommand({
       id: 'insert-citation',
       name: 'Insert literature note link',
       hotkeys: [{ modifiers: ['Ctrl', 'Shift'], key: 'e' }],


### PR DESCRIPTION
thanks for this fantastic plugin!

I've posted an issue(#83) about the plugin cannot auto-update the bib data, and thanks for @Mara-Li, I know there is already an issue(#52) about this. I found that the debug last for a long time, as issue #52 began in January. This PR adds a command for manual update the bib data rather than auto-update, which may fail with some users like me. I think it can be a workaround while we are still debugging the issue. After debugging, I think this command can be removed.

I've tested this on my MacBook:
1. I add a new item in Zotero when Obsidian is already opened
2. I open citation with `ctrl+shift+E` and cannot find the new item
3. I run the command `update bib data` with `ctrl/cmd+P` or press shortcut `ctrl+shift+R`
4. I open citation with `ctrl+shift+E` again and find the new item