### PR TITLE
Fix bug with citations failing to auto update 

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -115,7 +115,10 @@ export default class CitationPlugin extends Plugin {
         };
 
         chokidar
-          .watch(this.settings.citationExportPath, watchOptions)
+          .watch(
+            this.resolveLibraryPath(this.settings.citationExportPath),
+            watchOptions,
+          )
           .on('change', () => {
             this.loadLibrary();
           });


### PR DESCRIPTION
The fix is to resolve the citation export path relative to the vault
root before passing the path to chokidar.

Note: The citations still take a couple seconds to update after placing
an item in zotero. It might be useful to add a notifier to indicate
when the citations have updated. This notifier could go in the
loadLibrary function but then it would be displayed whenever the
application opens which is not very helpful. My suggestion is to
wrap `loadLibrary` in a function called `refreshLibrary` that also
shows a notification "Citations updated."


Fixes #34 
Fixes #98 
Fixes #52 