### PR TITLE
Use event handlers for managing library load start/finish

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,19 @@
+/**
+ * Defines an event manager for the citations plugin.
+ */
+
+import { Events, EventRef } from 'obsidian';
+
+export default class CitationEvents extends Events {
+  on(name: 'library-load-start', callback: () => any, ctx?: any): EventRef;
+  on(name: 'library-load-complete', callback: () => any, ctx?: any): EventRef;
+  on(name: string, callback: (...data: any[]) => any, ctx?: any): EventRef {
+    return super.on(name, callback, ctx);
+  }
+
+  trigger(name: 'library-load-start'): void;
+  trigger(name: 'library-load-complete'): void;
+  trigger(name: string, ...data: any[]): void {
+    super.trigger(name, data);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,8 @@ import {
   TemplateDelegate as Template,
 } from 'handlebars';
 
+
+import CitationEvents from './events';
 import {
   InsertCitationModal,
   InsertNoteLinkModal,
@@ -51,6 +53,8 @@ export default class CitationPlugin extends Plugin {
   private loadWorker = new WorkerManager(new LoadWorker(), {
     blockingChannel: true,
   });
+
+  events = new CitationEvents();
 
   loadErrorNotifier = new Notifier(
     'Unable to load citations. Please update Citations plugin settings.',
@@ -199,6 +203,7 @@ export default class CitationPlugin extends Plugin {
       );
 
       // Unload current library.
+      this.events.trigger('library-load-start');
       this.library = null;
 
       return FileSystemAdapter.readLocalFile(filePath)
@@ -239,6 +244,8 @@ export default class CitationPlugin extends Plugin {
           console.debug(
             `Citation plugin: successfully loaded library with ${this.library.size} entries.`,
           );
+
+          this.events.trigger('library-load-complete');
 
           return this.library;
         })

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -93,6 +93,9 @@ class SearchModal extends FuzzySuggestModal<Entry> {
       this.loadingEl.addClass('d-none');
       this.inputEl.disabled = false;
       this.inputEl.focus();
+
+      // @ts-ignore: not exposed in API.
+      this.updateSuggestions();
     }
   }
 

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -1,5 +1,6 @@
 import {
   App,
+  EventRef,
   FuzzyMatch,
   FuzzySuggestModal,
   Notice,
@@ -23,9 +24,8 @@ class SearchModal extends FuzzySuggestModal<Entry> {
   limit = 50;
 
   loadingEl: HTMLElement;
-  loadingCheckerHandle: NodeJS.Timeout;
-  // How frequently should we check whether the library is still loading?
-  loadingCheckInterval = 250;
+
+  eventRefs: EventRef[];
 
   constructor(app: App, plugin: CitationPlugin) {
     super(app);
@@ -47,10 +47,17 @@ class SearchModal extends FuzzySuggestModal<Entry> {
   onOpen() {
     super.onOpen();
 
-    this.checkLoading();
-    this.loadingCheckerHandle = setInterval(() => {
-      this.checkLoading();
-    }, this.loadingCheckInterval);
+    this.eventRefs = [
+      this.plugin.events.on('library-load-start', () => {
+        this.setLoading(true);
+      }),
+
+      this.plugin.events.on('library-load-complete', () => {
+        this.setLoading(false);
+      }),
+    ];
+
+    this.setLoading(this.plugin.isLibraryLoading);
 
     // Don't immediately register keyevent listeners. If the modal was triggered
     // by an "Enter" keystroke (e.g. via the Obsidian command dialog), this event
@@ -62,25 +69,7 @@ class SearchModal extends FuzzySuggestModal<Entry> {
   }
 
   onClose() {
-    if (this.loadingCheckerHandle) {
-      clearInterval(this.loadingCheckerHandle);
-    }
-  }
-
-  /**
-   * Check if the library is currently being loaded. If so, display animation
-   * and disable input. Otherwise hide animation and enable input.
-   */
-  checkLoading() {
-    if (this.plugin.isLibraryLoading) {
-      this.loadingEl.removeClass('d-none');
-      this.inputEl.disabled = true;
-      this.resultContainerEl.empty();
-    } else {
-      this.loadingEl.addClass('d-none');
-      this.inputEl.disabled = false;
-      this.inputEl.focus();
-    }
+    this.eventRefs?.forEach((e) => this.plugin.events.offref(e));
   }
 
   getItems(): Entry[] {
@@ -93,6 +82,18 @@ class SearchModal extends FuzzySuggestModal<Entry> {
 
   getItemText(item: Entry): string {
     return `${item.title} ${item.authorString} ${item.year}`;
+  }
+
+  setLoading(loading: boolean): void {
+    if (loading) {
+      this.loadingEl.removeClass('d-none');
+      this.inputEl.disabled = true;
+      this.resultContainerEl.empty();
+    } else {
+      this.loadingEl.addClass('d-none');
+      this.inputEl.disabled = false;
+      this.inputEl.focus();
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/obsidian-extensions.d.ts
+++ b/src/obsidian-extensions.d.ts
@@ -1,8 +1,9 @@
 /**
  * Hackily exposes undocumented parts of the Obsidian implementation for our use.
+ * Also extends some types to make our lives easier.
  */
 
-import { Vault } from 'obsidian';
+import { EventRef, Vault, Workspace } from 'obsidian';
 
 export class VaultExt extends Vault {
   getConfig(key: string): any;


### PR DESCRIPTION
Cleaner and more extensible than polling from the modal.