### PR TITLE
change: quote default literatureNoteContentTemplate

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,8 +23,8 @@ export class CitationsPluginSettings {
   literatureNoteFolder = 'Reading notes';
   literatureNoteContentTemplate: string =
     '---\n' +
-    'title: {{title}}\n' +
-    'authors: {{authorString}}\n' +
+    'title: "{{title}}"\n' +
+    'authors: "{{authorString}}"\n' +
     'year: {{year}}\n' +
     '---\n\n';
 


### PR DESCRIPTION
The default value of `literatureNoteContentTemplate` will generate YAML front matter that is often broken by special YAML characters. For instance, a colon (`:`) in the {{title}} will cause a syntax error in YAML. This adds quotes around both `{{title}}` and `{{authorString}}` in an attempt to remedy the easily-broken default.

For example, I created a literature note which contains a colon in the title. This is the result using the previous default template:

```yaml
---
title: Ontology development 101: A guide to creating your first ontology
authors: Natalya F. Noy, Deborah L. McGuinness
year: 2001
---
```

(try this snippet in [YAML Lint](http://www.yamllint.com/)!)

Obsidian presents this as "Metadata (invalid YAML)" in the preview:

![The message within Obsidian reading "Metadata (invalid YAML)"](https://user-images.githubusercontent.com/2294397/143242827-b34cb255-07a7-4fa9-9a55-4188fc79ae84.png)

After the change, the front matter is as follows:

```yaml
---
title: "Ontology development 101: A guide to creating your first ontology"
authors: "Natalya F. Noy, Deborah L. McGuinness"
year: 2001
---
```

After this change, the default is no longer broken by the titles containing colons or other YAML syntax.

Note: this may be considered a breaking change, as it changes the defaults of the plugin.

Fixes #117
Addresses #89