### PR TITLE
Replace `[Link]` placeholder by actual link's text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "obsidian-citation-plugin",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.2",
+      "name": "obsidian-citation-plugin",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
-        "@retorquere/bibtex-parser": "^3.2.30",
+        "@retorquere/bibtex-parser": "^6.0.1",
         "chokidar": "^3.5.0",
         "handlebars": "^4.7.6",
         "open": "^7.3.0",
@@ -378,12 +379,15 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
-      "integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.16.3.tgz",
+      "integrity": "sha512-IAdDC7T0+wEB4y2gbIL0uOXEYpiZEeuFUTVbdGq+UwCcF35T/tS8KrmMomEwEc5wBbyfH3PJVpTSUqrhPDXFcQ==",
       "dependencies": {
-        "core-js-pure": "^3.0.0",
+        "core-js-pure": "^3.19.0",
         "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -783,13 +787,12 @@
       }
     },
     "node_modules/@retorquere/bibtex-parser": {
-      "version": "3.2.30",
-      "resolved": "https://registry.npmjs.org/@retorquere/bibtex-parser/-/bibtex-parser-3.2.30.tgz",
-      "integrity": "sha512-92NCnRWbwfH0eErsTC4SrUvGz5QGZpze4+7nsui76BwQ+3OsENbqzPnm9d+sY8O0dGJ/4sx2gPr1dggIdDr2Kw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@retorquere/bibtex-parser/-/bibtex-parser-6.0.1.tgz",
+      "integrity": "sha512-NHOFxU98dr1u48Rh90FaehNTexei1VVKbcIA6WE/oflC6ojeklC6Y4sKNcH580eJ3hgssCkRvNXUh4oSK8Guhw==",
       "dependencies": {
-        "chevrotain": "^7.0.3",
-        "unicode2latex": "^2.1.35",
-        "xregexp": "^4.4.1"
+        "unicode2latex": "^2.1.36",
+        "xregexp": "^5.1.0"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -1791,14 +1794,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/chevrotain": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.0.tgz",
-      "integrity": "sha512-msTqYIGb+8z4UpNxliBlowlfFJtBQjTSdnOWgMD/llcE5cQHDbFMjHGdCMJSsPG/Op89c6/ERCmYku4UHDhHVA==",
-      "dependencies": {
-        "regexp-to-ast": "0.5.0"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.0.tgz",
@@ -1983,10 +1978,14 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.2.tgz",
-      "integrity": "sha512-v6zfIQqL/pzTVAbZvYUozsxNfxcFb6Ks3ZfEbuneJl3FW9Jb8F6vLWB6f+qTmAu72msUdyb84V8d/yBFf7FNnw==",
-      "hasInstallScript": true
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.19.1.tgz",
+      "integrity": "sha512-Q0Knr8Es84vtv62ei6/6jXH/7izKmOrtrxH9WJTHLCMAVeU+8TF8z8Nr08CsH4Ot0oJKzBzJJL9SJBYIv7WlfQ==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -5671,9 +5670,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/regex-not": {
       "version": "1.0.2",
@@ -5687,11 +5686,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/regexp-to-ast": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
     },
     "node_modules/regexpp": {
       "version": "3.1.0",
@@ -7132,9 +7126,9 @@
       }
     },
     "node_modules/unicode2latex": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/unicode2latex/-/unicode2latex-2.1.35.tgz",
-      "integrity": "sha512-W4n1WUXycwvMOpkG+8GrAeelVnUYdCfaqg+ppnoukRkOCgvapjvpqB40a+6FxzL82YR2c5X4+kRUfN7cw0ZQZw=="
+      "version": "2.1.36",
+      "resolved": "https://registry.npmjs.org/unicode2latex/-/unicode2latex-2.1.36.tgz",
+      "integrity": "sha512-87ZQi9csv5dwVx56rmD6ErMMl47gI+HBFOdiPimBY9OgUlbMPHLJspe3ym5/u56oIwR3NGoSK0K66V7GmCt2Lw=="
     },
     "node_modules/union-value": {
       "version": "1.0.1",
@@ -7494,11 +7488,11 @@
       "dev": true
     },
     "node_modules/xregexp": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.4.1.tgz",
-      "integrity": "sha512-2u9HwfadaJaY9zHtRRnH6BY6CQVNQKkYm3oLtC9gJXXzfsbACg5X5e4EZZGVAH+YIfa+QA9lsFQTTe3HURF3ag==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.0.tgz",
+      "integrity": "sha512-PynwUWtXnSZr8tpQlDPMZfPTyv78EYuA4oI959ukxcQ0a9O/lvndLVKy5wpImzzA26eMxpZmnAXJYiQA13AtWA==",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.12.1"
+        "@babel/runtime-corejs3": "^7.14.9"
       }
     },
     "node_modules/y18n": {
@@ -7880,11 +7874,11 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
-      "integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.16.3.tgz",
+      "integrity": "sha512-IAdDC7T0+wEB4y2gbIL0uOXEYpiZEeuFUTVbdGq+UwCcF35T/tS8KrmMomEwEc5wBbyfH3PJVpTSUqrhPDXFcQ==",
       "requires": {
-        "core-js-pure": "^3.0.0",
+        "core-js-pure": "^3.19.0",
         "regenerator-runtime": "^0.13.4"
       }
     },
@@ -8223,13 +8217,12 @@
       }
     },
     "@retorquere/bibtex-parser": {
-      "version": "3.2.30",
-      "resolved": "https://registry.npmjs.org/@retorquere/bibtex-parser/-/bibtex-parser-3.2.30.tgz",
-      "integrity": "sha512-92NCnRWbwfH0eErsTC4SrUvGz5QGZpze4+7nsui76BwQ+3OsENbqzPnm9d+sY8O0dGJ/4sx2gPr1dggIdDr2Kw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@retorquere/bibtex-parser/-/bibtex-parser-6.0.1.tgz",
+      "integrity": "sha512-NHOFxU98dr1u48Rh90FaehNTexei1VVKbcIA6WE/oflC6ojeklC6Y4sKNcH580eJ3hgssCkRvNXUh4oSK8Guhw==",
       "requires": {
-        "chevrotain": "^7.0.3",
-        "unicode2latex": "^2.1.35",
-        "xregexp": "^4.4.1"
+        "unicode2latex": "^2.1.36",
+        "xregexp": "^5.1.0"
       }
     },
     "@rollup/plugin-commonjs": {
@@ -9074,14 +9067,6 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
-    "chevrotain": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.0.tgz",
-      "integrity": "sha512-msTqYIGb+8z4UpNxliBlowlfFJtBQjTSdnOWgMD/llcE5cQHDbFMjHGdCMJSsPG/Op89c6/ERCmYku4UHDhHVA==",
-      "requires": {
-        "regexp-to-ast": "0.5.0"
-      }
-    },
     "chokidar": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.0.tgz",
@@ -9241,9 +9226,9 @@
       "dev": true
     },
     "core-js-pure": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.2.tgz",
-      "integrity": "sha512-v6zfIQqL/pzTVAbZvYUozsxNfxcFb6Ks3ZfEbuneJl3FW9Jb8F6vLWB6f+qTmAu72msUdyb84V8d/yBFf7FNnw=="
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.19.1.tgz",
+      "integrity": "sha512-Q0Knr8Es84vtv62ei6/6jXH/7izKmOrtrxH9WJTHLCMAVeU+8TF8z8Nr08CsH4Ot0oJKzBzJJL9SJBYIv7WlfQ=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -12200,9 +12185,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -12213,11 +12198,6 @@
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
-    },
-    "regexp-to-ast": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
     },
     "regexpp": {
       "version": "3.1.0",
@@ -13391,9 +13371,9 @@
       "optional": true
     },
     "unicode2latex": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/unicode2latex/-/unicode2latex-2.1.35.tgz",
-      "integrity": "sha512-W4n1WUXycwvMOpkG+8GrAeelVnUYdCfaqg+ppnoukRkOCgvapjvpqB40a+6FxzL82YR2c5X4+kRUfN7cw0ZQZw=="
+      "version": "2.1.36",
+      "resolved": "https://registry.npmjs.org/unicode2latex/-/unicode2latex-2.1.36.tgz",
+      "integrity": "sha512-87ZQi9csv5dwVx56rmD6ErMMl47gI+HBFOdiPimBY9OgUlbMPHLJspe3ym5/u56oIwR3NGoSK0K66V7GmCt2Lw=="
     },
     "union-value": {
       "version": "1.0.1",
@@ -13698,11 +13678,11 @@
       "dev": true
     },
     "xregexp": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.4.1.tgz",
-      "integrity": "sha512-2u9HwfadaJaY9zHtRRnH6BY6CQVNQKkYm3oLtC9gJXXzfsbACg5X5e4EZZGVAH+YIfa+QA9lsFQTTe3HURF3ag==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.0.tgz",
+      "integrity": "sha512-PynwUWtXnSZr8tpQlDPMZfPTyv78EYuA4oI959ukxcQ0a9O/lvndLVKy5wpImzzA26eMxpZmnAXJYiQA13AtWA==",
       "requires": {
-        "@babel/runtime-corejs3": "^7.12.1"
+        "@babel/runtime-corejs3": "^7.14.9"
       }
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@retorquere/bibtex-parser": "^3.2.30",
+    "@retorquere/bibtex-parser": "^6.0.1",
     "chokidar": "^3.5.0",
     "handlebars": "^4.7.6",
     "open": "^7.3.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,7 +172,7 @@ export abstract class Entry {
 
   public get note(): string {
     return this._note
-      ?.map((el) => el.replace(/(zotero:\/\/.+)/g, '[Link]($1)'))
+      ?.map((el) => el.replace(/<a\s+href="([^"]+)">([^<]*)<\/a>/g, '[$2]($1)'))
       .join('\n\n');
   }
 


### PR DESCRIPTION
Changes:
- Bump https://github.com/retorquere/bibtex-parser to `6.0.1`
- Handle new link syntax to translate `<a href="…">my note link</a>` to `[my note link](…)` instead of `[Link](…)`

Fixes #125

@hans, I can also make the change to translate `<i>` & `<b>` tags to the corresponding syntax in markdown ?