### PR TITLE
Make citekey follow theme monospace font

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -57,7 +57,7 @@
 .zoteroCitekey {
   color: #555;
   font-size: 13px;
-  font-family: monospace;
+  font-family: var(--font-monospace), monospace;
   display: inline-block;
   margin-right: 5px;
   padding-right: 5px;


### PR DESCRIPTION
- update `styles.css`
  - modify the `font-family` of `.zoteroCitekey` to follow the theme's
    monospace font
  - use `monospace` as a backup in case `var(--font-monospace)` isn't in
    the theme file