### PR TITLE
Make issuedDate returning date in UTC timezone instead of local for CSL-JSON

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -277,7 +277,7 @@ export class EntryCSLAdapter extends Entry {
       return null;
 
     const [year, month, day] = this.data.issued['date-parts'][0];
-    return new Date(year, (month || 1) - 1, day || 1);
+    return new Date(Date.UTC(year, (month || 1) - 1, day || 1));
   }
 
   get page() {


### PR DESCRIPTION
The issue wasn't OS-specific. The problem was that `EntryCSLAdapter.issuedDate()` returned date in the local time zone which then was converted to UTC in `Entry.year()` where the timeshift could occur. If the Local time zone was with the positive offset, then this offset was removed (the date is shifted from Jan 01 to Dec 31 of the previous year). Otherwise, the offset was added which didn't year change.

Fixes #40