### PR TITLE
Template variable for short title

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ You can set up your own template for both the title and content of literature no
 * {{publisher}}
 * {{publisherPlace}}
 * {{title}}
+* {{titleShort}}
 * {{URL}}
 * {{year}}
 * {{zoteroSelectURI}}

--- a/src/__tests__/types.spec.ts
+++ b/src/__tests__/types.spec.ts
@@ -45,6 +45,7 @@ const expectedRender: Record<string, string>[] = [
     page: undefined,
     title:
       'Blackbox meets blackbox: Representational Similarity and Stability Analysis of Neural Language Models and Brains',
+    titleShort: "Blackbox meets blackbox",
     URL: 'http://arxiv.org/abs/1906.01539',
     year: '2019',
     zoteroSelectURI: 'zotero://select/items/@abnar2019blackbox',

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export const TEMPLATE_VARIABLES = {
   publisher: '',
   publisherPlace: 'Location of publisher',
   title: '',
+  titleShort: '',
   URL: '',
   year: 'Publication year',
   zoteroSelectURI: 'URI to open the reference in Zotero',
@@ -60,6 +61,7 @@ export class Library {
       publisher: entry.publisher,
       publisherPlace: entry.publisherPlace,
       title: entry.title,
+      titleShort: entry.titleShort,
       URL: entry.URL,
       year: entry.year?.toString(),
       zoteroSelectURI: entry.zoteroSelectURI,
@@ -148,6 +150,7 @@ export abstract class Entry {
    */
   public abstract page?: string;
   public abstract title?: string;
+  public abstract titleShort?: string;
   public abstract URL?: string;
 
   public abstract eventPlace?: string;
@@ -222,6 +225,7 @@ export interface EntryDataCSL {
   publisher?: string;
   'publisher-place'?: string;
   title?: string;
+  'title-short'?: string;
   URL?: string;
 }
 
@@ -294,6 +298,10 @@ export class EntryCSLAdapter extends Entry {
 
   get title() {
     return this.data.title;
+  }
+
+  get titleShort() {
+    return this.data['title-short'];
   }
 
   get URL() {


### PR DESCRIPTION
Pull request exposes short titles via `{{titleShort}}` template variable. Fixes #77.