### PR TITLE
Fix insertion of literature reference in canvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -457,6 +457,25 @@
         "node": ">=0.1.95"
       }
     },
+    "node_modules/@codemirror/state": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
+      "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.14.1.tgz",
+      "integrity": "sha512-ofcsI7lRFo4N0rfnd+V3Gh2boQU3DmaaSKhDOvXUWjeOeuupMXer2e/3i9TUFN7aEIntv300EFBWPEiYVm2svg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.1.4",
+        "style-mod": "^4.0.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
@@ -940,9 +959,9 @@
       }
     },
     "node_modules/@types/codemirror": {
-      "version": "0.0.98",
-      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.98.tgz",
-      "integrity": "sha512-cbty5LPayy2vNSeuUdjNA9tggG+go5vAxmnLDRWpiZI5a+RDBi9dlozy4/jW/7P/gletbBWbQREEa7A81YxstA==",
+      "version": "5.60.8",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+      "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
       "dev": true,
       "dependencies": {
         "@types/tern": "*"
@@ -1049,9 +1068,9 @@
       "dev": true
     },
     "node_modules/@types/tern": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.3.tgz",
-      "integrity": "sha512-imDtS4TAoTcXk0g7u4kkWqedB3E4qpjXzCpD2LU5M5NAXHzCDsypyvXSaG7mM8DKYkCRa7tFp4tS/lp/Wo7Q3w==",
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
+      "integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*"
@@ -4980,6 +4999,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5183,12 +5211,17 @@
       }
     },
     "node_modules/obsidian": {
-      "version": "0.11.0",
-      "resolved": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#81ab85ade4552c9116c1e10d009127e62019c923",
+      "version": "1.2.8",
+      "resolved": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#971b9e83ca65f0c3655346938167f666a8a868ff",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/codemirror": "0.0.98"
+        "@types/codemirror": "5.60.8",
+        "moment": "2.29.4"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
       }
     },
     "node_modules/once": {
@@ -6761,6 +6794,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.3.tgz",
+      "integrity": "sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -7310,6 +7350,13 @@
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "2.0.0",
@@ -7952,6 +7999,25 @@
         "minimist": "^1.2.0"
       }
     },
+    "@codemirror/state": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
+      "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw==",
+      "dev": true,
+      "peer": true
+    },
+    "@codemirror/view": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.14.1.tgz",
+      "integrity": "sha512-ofcsI7lRFo4N0rfnd+V3Gh2boQU3DmaaSKhDOvXUWjeOeuupMXer2e/3i9TUFN7aEIntv300EFBWPEiYVm2svg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@codemirror/state": "^6.1.4",
+        "style-mod": "^4.0.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
@@ -8370,9 +8436,9 @@
       }
     },
     "@types/codemirror": {
-      "version": "0.0.98",
-      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.98.tgz",
-      "integrity": "sha512-cbty5LPayy2vNSeuUdjNA9tggG+go5vAxmnLDRWpiZI5a+RDBi9dlozy4/jW/7P/gletbBWbQREEa7A81YxstA==",
+      "version": "5.60.8",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+      "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
       "dev": true,
       "requires": {
         "@types/tern": "*"
@@ -8479,9 +8545,9 @@
       "dev": true
     },
     "@types/tern": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.3.tgz",
-      "integrity": "sha512-imDtS4TAoTcXk0g7u4kkWqedB3E4qpjXzCpD2LU5M5NAXHzCDsypyvXSaG7mM8DKYkCRa7tFp4tS/lp/Wo7Q3w==",
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
+      "integrity": "sha512-JAUw1iXGO1qaWwEOzxTKJZ/5JxVeON9kvGZ/osgZaJImBnyjyn0cjovPsf6FNLmyGY8Vw9DoXZCMlfMkMwHRWg==",
       "dev": true,
       "requires": {
         "@types/estree": "*"
@@ -11642,6 +11708,12 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -11815,11 +11887,12 @@
       }
     },
     "obsidian": {
-      "version": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#81ab85ade4552c9116c1e10d009127e62019c923",
+      "version": "git+ssh://git@github.com/obsidianmd/obsidian-api.git#971b9e83ca65f0c3655346938167f666a8a868ff",
       "dev": true,
       "from": "obsidian@git+https://github.com/obsidianmd/obsidian-api.git#master",
       "requires": {
-        "@types/codemirror": "0.0.98"
+        "@types/codemirror": "5.60.8",
+        "moment": "2.29.4"
       }
     },
     "once": {
@@ -13100,6 +13173,13 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "style-mod": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.3.tgz",
+      "integrity": "sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw==",
+      "dev": true,
+      "peer": true
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -13542,6 +13622,13 @@
       "requires": {
         "browser-process-hrtime": "^1.0.0"
       }
+    },
+    "w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "peer": true
     },
     "w3c-xmlserializer": {
       "version": "2.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import {
   FileSystemAdapter,
+  ItemView,
   MarkdownSourceView,
   MarkdownView,
   normalizePath,
@@ -64,7 +65,15 @@ export default class CitationPlugin extends Plugin {
   );
 
   get editor(): CodeMirror.Editor {
-    const view = this.app.workspace.activeLeaf.view;
+    const view = this.app.workspace.getActiveViewOfType(ItemView);
+
+    if (view.getViewType() == 'canvas') {
+      if (this.app.workspace.activeEditor !== undefined) {
+        const canvasActiveEditor = this.app.workspace.activeEditor;
+        return canvasActiveEditor.editor;
+      }
+    }
+
     if (!(view instanceof MarkdownView)) return null;
 
     const sourceView = view.sourceMode;
@@ -392,7 +401,7 @@ export default class CitationPlugin extends Plugin {
           linkText = `[[${title}]]`;
         }
 
-        this.editor.replaceSelection(linkText);
+        this.editor.replaceRange(linkText, this.editor.getCursor());
       })
       .catch(console.error);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import {
+  Editor,
   FileSystemAdapter,
   ItemView,
   MarkdownSourceView,
@@ -15,7 +16,6 @@ import {
   compile as compileTemplate,
   TemplateDelegate as Template,
 } from 'handlebars';
-
 
 import CitationEvents from './events';
 import {
@@ -64,20 +64,8 @@ export default class CitationPlugin extends Plugin {
     'Unable to access literature note. Please check that the literature note folder exists, or update the Citations plugin settings.',
   );
 
-  get editor(): CodeMirror.Editor {
-    const view = this.app.workspace.getActiveViewOfType(ItemView);
-
-    if (view.getViewType() == 'canvas') {
-      if (this.app.workspace.activeEditor !== undefined) {
-        const canvasActiveEditor = this.app.workspace.activeEditor;
-        return canvasActiveEditor.editor;
-      }
-    }
-
-    if (!(view instanceof MarkdownView)) return null;
-
-    const sourceView = view.sourceMode;
-    return (sourceView as MarkdownSourceView).cmEditor;
+  get editor(): Editor {
+    return this.app.workspace.activeEditor.editor;
   }
 
   async loadSettings(): Promise<void> {


### PR DESCRIPTION
Currently, it is not possible to add literature references or markdown citations to Obsidian canvas.

This fix enables editor access for canvas (as opposed to editor access for Markdown files only). It is a "quick and dirty" fix, as there is no convenient API for canvas (yet).

Excepted behavior:
- Open canvas
- Select inserted markdown file node or canvas-only text node
- Enter "edit mode" in respective node
- Add literature reference
- Literature reference is added in currently active node

Tested in Obsidian v1.3.5.

Should fix https://github.com/hans/obsidian-citation-plugin/issues/217.