### PR TITLE
Support Zotero PDF URI links

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import {
   InsertCitationModal,
   InsertNoteLinkModal,
   InsertNoteContentModal,
+  InsertZoteroLinkModal,
   OpenNoteModal,
 } from './modals';
 import { VaultExt } from './obsidian-extensions.d';
@@ -167,6 +168,15 @@ export default class CitationPlugin extends Plugin {
       name: 'Insert literature note content in the current pane',
       callback: () => {
         const modal = new InsertNoteContentModal(this.app, this);
+        modal.open();
+      },
+    });
+
+    this.addCommand({
+      id: 'insert-zotero-link',
+      name: 'Insert Zotero link to pdf or entry',
+      callback: () => {
+        const modal = new InsertZoteroLinkModal(this.app, this);
         modal.open();
       },
     });
@@ -334,6 +344,16 @@ export default class CitationPlugin extends Plugin {
     );
   }
 
+  getEntryZoteroLinkForCitekey(citekey: string): string {
+    return `[${citekey}](zotero://select/items/${citekey})`;
+  }
+
+  getPdfZoteroLinkForCitekey(citekey: string): string {
+    const variables = this.library.getTemplateVariablesForCitekey(citekey);
+    return `[${citekey}:pdf](${variables.zoteroPdfURI})`;
+  }
+
+
   /**
    * Run a case-insensitive search for the literature note file corresponding to
    * the given citekey. If no corresponding file is found, create one.
@@ -416,5 +436,17 @@ export default class CitationPlugin extends Plugin {
     const citation = func.bind(this)(citekey);
 
     this.editor.replaceRange(citation, this.editor.getCursor());
+  }
+
+  async insertZoteroLink(
+    citekey: string,
+    alternative = false,
+  ): Promise<void> {
+    const func = alternative
+      ? this.getEntryZoteroLinkForCitekey
+      : this.getPdfZoteroLinkForCitekey;
+    const link = func.bind(this)(citekey);
+
+    this.editor.replaceRange(link, this.editor.getCursor());
   }
 }

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -258,6 +258,30 @@ export class InsertNoteContentModal extends SearchModal {
   }
 }
 
+export class InsertZoteroLinkModal extends SearchModal {
+  constructor(app: App, plugin: CitationPlugin) {
+    super(app, plugin);
+
+    this.setInstructions([
+      { command: '↑↓', purpose: 'to navigate' },
+      {
+        command: '↵',
+        purpose: 'to insert Zotero Link to pdf',
+      },
+      { command: 'shift ↵', purpose: 'to insert Zoter Link to entry' },
+      { command: 'esc', purpose: 'to dismiss' },
+    ]);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onChooseItem(item: Entry, evt: MouseEvent | KeyboardEvent): void {
+    const isAlternative = evt instanceof KeyboardEvent && evt.shiftKey;
+    this.plugin
+      .insertZoteroLink(item.id, isAlternative)
+      .catch(console.error);
+  }
+}
+
 export class InsertCitationModal extends SearchModal {
   constructor(app: App, plugin: CitationPlugin) {
     super(app, plugin);

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export const TEMPLATE_VARIABLES = {
   URL: '',
   year: 'Publication year',
   zoteroSelectURI: 'URI to open the reference in Zotero',
+  zoteroPdfURI: 'URI to open the PDF attachment in Zotero',
+  zoteroPdfHash: 'Hash of the PDF attachment',
 };
 
 export class Library {
@@ -65,6 +67,8 @@ export class Library {
       URL: entry.URL,
       year: entry.year?.toString(),
       zoteroSelectURI: entry.zoteroSelectURI,
+      zoteroPdfURI: entry.zoteroPdfURI,
+      zoteroPdfHash: entry.zoteroPdfHash,
     };
 
     return { entry: entry.toJSON(), ...shortcuts };
@@ -197,6 +201,28 @@ export abstract class Entry {
    */
   public get zoteroSelectURI(): string {
     return `zotero://select/items/@${this.id}`;
+  }
+
+  public get zoteroPdfHash(): string {
+    const files = this.files || [];
+
+    const pdfPath = files.find((f) => f.toLowerCase().endsWith('.pdf'));
+
+    if (!pdfPath) {
+      return null;
+    }
+    const idxStorage = pdfPath.toLowerCase().indexOf('/storage/');
+    const pdfHash = pdfPath.substring(idxStorage + 9, idxStorage + 9 + 8);
+    return pdfHash;
+  }
+
+  public get zoteroPdfURI(): string {
+    const hashPdf = this.zoteroPdfHash;
+    if (hashPdf) {
+      return `zotero://open-pdf/library/items/${hashPdf}`;
+    } else {
+      return null;
+    }
   }
 
   toJSON(): Record<string, unknown> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import * as BibTeXParser from '@retorquere/bibtex-parser';
 import { Entry as EntryDataBibLaTeX } from '@retorquere/bibtex-parser';
+import { has } from 'lodash';
 // Also make EntryDataBibLaTeX available to other modules
 export { Entry as EntryDataBibLaTeX } from '@retorquere/bibtex-parser';
 


### PR DESCRIPTION
First: I'm not a programmer, and I have never used Type Script before. But I use both Obsidian and Zotero, and I really like the plug-in. I spent a whole day to find a way to link to the PDF stored in Zotero directly from Obsidian and did not find a solution. 

So I gave it a try to implement it myself. It is probably not the most elegant solution, but it works. I really like it, as it saves me a lot of time switching between Zotero and Obsidian, and maybe somebody who knows what they are doing can reimplement the same functionality.

Basically, the pdf location is read from the "file" entry of the bib file, and then the URI link to Zotero is created based on that. The resulting URI is available both as a template variable and as a stand-alone command.

Otherwise, it may be helpful for others.