### PR TITLE
fix: bug all vault search not working

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -339,21 +339,24 @@ export default class CitationPlugin extends Plugin {
    * the given citekey. If no corresponding file is found, create one.
    */
   async getOrCreateLiteratureNoteFile(citekey: string): Promise<TFile> {
-    const path = this.getPathForCitekey(citekey);
-    const normalizedPath = normalizePath(path);
+    const filePath = this.getPathForCitekey(citekey);
+    const normalizedPath = normalizePath(filePath);
 
     let file = this.app.vault.getAbstractFileByPath(normalizedPath);
     if (file == null) {
+      const splittedPath = normalizedPath.split(path.sep);
+      const fileName = splittedPath[splittedPath.length - 1].toLowerCase();
+
       // First try a case-insensitive lookup.
       const matches = this.app.vault
         .getMarkdownFiles()
-        .filter((f) => f.path.toLowerCase() == normalizedPath.toLowerCase());
+        .filter((f) => f.name.toLowerCase() == fileName);
       if (matches.length > 0) {
         file = matches[0];
       } else {
         try {
           file = await this.app.vault.create(
-            path,
+            filePath,
             this.getInitialContentForCitekey(citekey),
           );
         } catch (exc) {


### PR DESCRIPTION
The old code didn't work if the file was on another directory because the path could include the folder names which implied if the file was in a subfolder, it couldn't find the file correctly.
It worked only for files in the same exact directory, with different case.

This PR fixes that and allows for vault wide search.

Implements #219 .